### PR TITLE
Downgrade to rust version '2021'.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,13 +5,16 @@
     "remoteUser": "vscode",
     "workspaceFolder": "/codeanalyzer-rs",
     "workspaceMount": "source=${localWorkspaceFolder},target=/codeanalyzer-rs,type=bind,consistency=delegated",
-    "runArgs": ["-h", "codenet"],
+    "runArgs": [
+        "-h",
+        "codenet"
+    ],
     "customizations": {
         "vscode": {
             "settings": {
                 "markdown-preview-github-styles.colorTheme": "light",
                 "cSpell.words": [
-                    "northstar",
+                    "cldk",
                     "cyclomatic",
                     "stdlibs"
                 ],

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.28"
+version = "4.5.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
+checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "codeanalyzer-rs"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 authors = ["Rithul Kamesh <hi@rithul.dev>"]
 description = "A code analysis tool written in Rust"
 license = "Apache-2.0"
@@ -11,5 +11,5 @@ keywords = ["code-analysis", "static-analysis", "rust"]
 categories = ["development-tools", "development-tools::testing"]
 
 [dependencies]
-clap = { version = "4.5.28", features = ["derive"] }
+clap = { version = "4.5.29", features = ["derive"] }
 serde = { version = "1.0.217", features = ["derive"] }


### PR DESCRIPTION
Downgraded rust edition to 2021 (from 2024).

## Motivation and Context
It ensures that the we don't have to use nightly to build this project. 

## How Has This Been Tested?
Tried to build with `cargo build --release`

## Breaking Changes
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [Codellm-Devkit Documentation](https://codellm-devkit.info)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
N/A
